### PR TITLE
Added support for the Brave browser and WebDriver path configuration

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -1,5 +1,6 @@
 [general]
-url = https://musescore.com/path/to/your/score
-file_name = render
-render_path = /path/to/your/render/folder
-
+url = https://musescore.com/user/xxx/scores/xxx
+file_name = render.pdf
+render_path = path/to/musecore2pdf
+binary_location = path/to/BraveSoftware/Brave-Browser/Application/brave.exe
+driver_path = path/to/chromedriver-win64/chromedriver.exe

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import time
 import tempfile
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.service import Service
 
 from configparser import ConfigParser
 
@@ -22,9 +23,16 @@ config.read("config.conf")
 url = config.get("general", "url")
 render_path = config.get("general", "render_path")
 file_name = config.get("general", "file_name")
+driver_path = config.get("general", "driver_path")
+binary_location = config.get("general", "binary_location")
 
 # open the browser
+if driver_path is not None and driver_path != "":
+    service = Service(executable_path=driver_path)
+
 options = webdriver.ChromeOptions()
+if binary_location is not None and binary_location != "":
+    options.binary_location = binary_location
 options.add_argument("--incognito")
 options.add_argument("window-size=1920,1080")
 options.add_argument("--headless")
@@ -33,7 +41,11 @@ options.add_argument("--disable-extensions")
 options.add_argument("--no-sandbox")
 options.add_argument("--disable-dev-shm-usage")
 
-browser = webdriver.Chrome(options=options)
+if driver_path is not None and driver_path != "":
+    browser = webdriver.Chrome(options=options, service=service)
+else:
+    browser = webdriver.Chrome(options=options)
+
 print("[INFO] Browser opened")
 browser.get(url)
 print("[INFO] Page loaded")


### PR DESCRIPTION
# Description

This PR aims to add support for the Brave browser by adding a `binary_location` parameter to the config file, thus allowing any end user to use any Chromium-based modified browser like Brave.
I also added a `driver_path` parameter in the config which allows to use the script without adding the WebDriver executable to the PATH.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested linking to the Brave executable
- [x] Tested linking to the Chrome WebDriver
- [ ] *Not tested* to use without the Brave executable linked in the config file
- [ ] *Not tested* to use without the Chrome WebDriver linked in the config file but added to the PATH.

**Test Configuration**:
* Firmware version: Brave browser, based on Chromium 122.0.6261.69;
* WebDriver version: Chrome WebDriver 122.0.6261.69
* Hardware: Windows 11 Home Edition
* Python version: 3.12.1

# Checklist:

- [ ] My code follows the style guidelines of this project --> None
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas --> self-documented I guess?
- [ ] I have made corresponding changes to the documentation --> README not updated
- [x] My changes generate no new warnings --> Old warnings still work 😅
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes --> No unit test
- [ ] Any dependent changes have been merged and published in downstream modules
