### PR TITLE
Patched 'Unable to find Chrome binary' bug + feature port

### DIFF
--- a/extraction.py
+++ b/extraction.py
@@ -65,7 +65,6 @@ class Extraction:
         if self.binary_location is not None and self.binary_location != "":
             options.binary_location = self.binary_location
 
-        options = webdriver.ChromeOptions()
         options.add_argument("--incognito")
         options.add_argument("window-size=1920,1080")
         options.add_argument("--headless")

--- a/no_gui.py
+++ b/no_gui.py
@@ -9,9 +9,12 @@ url = config.get("main.py", "url")
 render_path = config.get("main.py", "render_path")
 file_name = config.get("main.py", "file_name")
 
-if ".pdf" not in file_name:
-    file_name += ".pdf"
-
 # extract the PDF from the URL
 extraction = Extraction()
-extraction.extract(url, render_path+file_name)
+
+if file_name is not None and file_name != "":
+    if ".pdf" not in file_name:
+        file_name += ".pdf"
+    extraction.extract(url, render_path+file_name)
+else:
+    extraction.extract(url, render_path, True)


### PR DESCRIPTION
# Description

PR to solve the "Unable to find Chrome binary" error. The `options` variable initialisation was written twice, the second overwritting the first, which caused the error.
I also added the automatic file naming feature to the no_gui class. I know adding several features in 1 PR is bad practice, but the changes are very small.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested linking to the Brave executable
- [x] Tested linking to the Chrome WebDriver
- [x] Tested the automatic file naming feature in the no_gui class
- [x] Tested the enforced file naming feature in the no_gui class
- [ ] *Not tested:* Using it without the Brave executable linked in the config file
- [ ] *Not tested:* Using it without the Chrome WebDriver linked in the config file but added to the PATH.

**Test Configuration**:
* Firmware version: Brave browser, based on Chromium 122.0.6261.128;
* WebDriver version: Chrome WebDriver 122.0.6261.69
* Hardware: Windows 11 Home Edition
* Python version: 3.12.1

# Checklist:

- [x] My code follows the style guidelines of this project --> None
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas --> self-documented I guess?
- [x] I have made corresponding changes to the documentation --> no documentation change needed
- [x] My changes generate no new warnings --> Old warnings still work 😅
- [x] I have ~~added~~ *performed* tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes --> No unit test
- [x] Any dependent changes have been merged and published in downstream modules
